### PR TITLE
allow use addHandler with array of contentType

### DIFF
--- a/lib/Crawler.js
+++ b/lib/Crawler.js
@@ -297,6 +297,8 @@ Crawler.prototype._fireHandlers = function (contentType, body, url) {
 
     if (handlerContentType === "*") {
       match = true;
+    } else if (Array.isArray(handlerContentType) && (handlerContentType).indexOf(contentType) > -1) {
+      match = true;
     } else if ((contentType + "/").indexOf(handlerContentType + "/") === 0) {
       match = true;
     }


### PR DESCRIPTION
example 
```
let sitemapsParser = supercrawler.handlers.sitemapsParser();
crawler.addHandler([
  "text/xml",
  "application/x-gzip",
  "application/gzip",
  "application/octet-stream"], sitemapsParser);
```